### PR TITLE
Changed encode-path to use URLEncoder and replace + with %20, fix for issue #21 in neocons

### DIFF
--- a/src/clojure/clojurewerkz/urly/core.clj
+++ b/src/clojure/clojurewerkz/urly/core.clj
@@ -422,5 +422,6 @@
     (.toASCIIString u)))
 
 (defn ^String encode-path
+  "Escapes input as URI path"
   [^String s]
   (.replace (URLEncoder/encode s) "+" "%20"))

--- a/test/clojurewerkz/urly/test/core_test.clj
+++ b/test/clojurewerkz/urly/test/core_test.clj
@@ -805,4 +805,5 @@
 (deftest test-path-escaping
   (are [input output] (is (= (encode-path input) output))
     "nodes" "nodes"
-    "no des" "no%20des"))
+    "no des" "no%20des"
+    "no des with:" "no%20des%20with%3A"))


### PR DESCRIPTION
Changed encode-path to use URLEncoder and replace + with %20, fix for issue #21 in neocons.
Change passed all test cases in neocons and urly.
Haven't removed the old implementation, can be removed if it doesn't affect other projects in clojurewerks that uses urly.
